### PR TITLE
Revert "Change released dependencies branch to `release/6.1`"

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -168,7 +168,7 @@ let package = Package(
 )
 
 if !useLocalDependencies {
-  let relatedDependenciesBranch = "release/6.1"
+  let relatedDependenciesBranch = "main"
 
   // Building standalone.
   package.dependencies += [


### PR DESCRIPTION
Reverts swiftlang/swift-stress-tester#265

That PR should have targeted `release/6.1`, not `main`