### PR TITLE
Merge `timedOut` with `softTimeout`

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -126,16 +126,7 @@ public class StressTester {
           try report(document.moduleInterfaceGen())
         }
       } catch {
-        if case SourceKitError.softTimeout(request: let request, duration: _, instructions: let .some(instructions)) = error {
-          reportPerformanceMeasurement(request: request, instructions: instructions, reusingASTContext: nil)
-        }
-        if case SourceKitError.timedOut = error {
-          // Ignore timeout errors. In practice, we have always just added the timeouts to the XFails and keeping track
-          // of these timeouts is the major cause of stress tester failures, producing noise.
-          // We use instruction count measurements to keep track of performance.
-        } else {
-          errors.append(error)
-        }
+        errors.append(error)
       }
     }
 


### PR DESCRIPTION
Remove `softTimeout` since timeouts are no longer reported as issues, and make `timedOut` a soft error since faster runs could hit issues that aren't hit if they happen to timeout.