### PR TITLE
Revert "Change related dependencies branch to `release/6.2`"

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -168,7 +168,7 @@ let package = Package(
 )
 
 if !useLocalDependencies {
-  let relatedDependenciesBranch = "release/6.2"
+  let relatedDependenciesBranch = "main"
 
   // Building standalone.
   package.dependencies += [


### PR DESCRIPTION
https://github.com/swiftlang/swift-stress-tester/pull/270 accidentally targeted main instead of release/6.2